### PR TITLE
Feature/zsh supports vars and path

### DIFF
--- a/envr.ps1
+++ b/envr.ps1
@@ -9,6 +9,7 @@
 # Use with "source" from *bash* or *Windows PowerShell*
 # Usage:
 #   bash $> . envr.ps1
+#   zsh $> . ./envr.ps1
 #   WinPS $> . ./envr.ps1
 # You cannot use it directly; it will not set your environment variables.
 
@@ -303,7 +304,10 @@ _envr_bash_main () {
 }
 
 _envr_zsh_main () {
-    echo "TODO!"
+    # _envr_zsh_exit_if_not_sourced &&
+    echo "GO!"
+    _envr_check_for_config &&
+    echo $_ENVR_HAS_LOCAL_CONFIG
 }
 
 # detect shell and run main

--- a/envr.ps1
+++ b/envr.ps1
@@ -1,4 +1,4 @@
-# envar v0.0.0
+# envr v0.0.0
 # https://www.github.com/JPHutchins/envr
 # https://www.crumpledpaper.tech
 

--- a/tests/sh/test_aliases.sh
+++ b/tests/sh/test_aliases.sh
@@ -12,7 +12,7 @@ OLD_PATH="$PATH"
 OLD_ALS="$(alias)"
 OLD_PS1="${PS1:-}"
 
-. envr.ps1
+. ./envr.ps1
 
 assertEqual "$OLD_PATH" "$PATH"
 

--- a/tests/sh/test_empty.sh
+++ b/tests/sh/test_empty.sh
@@ -13,7 +13,11 @@ assertEqual "$OLD_PATH" "$PATH"
 assertEqual "$OLD_ALS" "$(alias)"
 
 # cut off the leading characters
-assertEqual "$(echo $PS1 | cut -c 9-)" "(envr)"
+if [[ -n "${BASH:-}" ]] ; then
+    assertEqual "$(echo $PS1 | cut -c 9-)" "(envr)"
+elif [[ -n "${ZSH_VERSION:-}" ]] ; then
+    assertEqual "$(echo $PS1 | cut -c 8-)" "(envr) "
+fi
 
 unsource
 

--- a/tests/sh/test_envars.sh
+++ b/tests/sh/test_envars.sh
@@ -11,7 +11,7 @@ OLD_PS1="${PS1:-}"
 
 assertContains "$OLD_ENV" "USER_VAR=original user value"
 
-. envr.ps1
+. ./envr.ps1
 
 assertEqual "$OLD_PATH" "$PATH"                
 assertEqual "$OLD_ALS" "$(alias)"              

--- a/tests/sh/test_full.sh
+++ b/tests/sh/test_full.sh
@@ -17,7 +17,7 @@ OLD_PS1="${PS1:-}"
 
 assertContains "$OLD_ENV" "USER_VAR=original user value"
 
-. envr.ps1
+. ./envr.ps1
 
 assertNotEqual "$OLD_ENV" "$(printenv)"
 assertNotEqual "$OLD_PATH" "$PATH"

--- a/tests/sh/test_path.sh
+++ b/tests/sh/test_path.sh
@@ -11,7 +11,7 @@ assertContains "$PATH" "/usr/local/bin"
 
 . ./envr.ps1
 
-assertEqual $OLD_ALS $(alias)
+assertEqual "$OLD_ALS" "$(alias)"
 
 assertNotEqual "$OLD_PATH" "$PATH"
 assertContains "$PATH" "/opt"
@@ -19,7 +19,7 @@ assertContains "$PATH" "/usr/local/bin"
 
 unsource
 
-assertEqual $OLD_PATH "$PATH"
+assertEqual "$OLD_PATH" "$PATH"
 assertNotContains "$PATH" "/opt"
 assertContains "$PATH" "/usr/local/bin"
 

--- a/tests/sh/test_path.sh
+++ b/tests/sh/test_path.sh
@@ -9,7 +9,7 @@ OLD_PS1="${PS1:-}"
 
 assertContains "$PATH" "/usr/local/bin"
 
-. envr.ps1
+. ./envr.ps1
 
 assertEqual $OLD_ALS $(alias)
 

--- a/tests/sh/test_project_options.sh
+++ b/tests/sh/test_project_options.sh
@@ -7,7 +7,7 @@ OLD_PATH="$PATH"
 OLD_ALS="$(alias)"
 OLD_PS1="${PS1:-}"
 
-. envr.ps1
+. ./envr.ps1
 
 assertEqual "$OLD_PATH" "$PATH" 
 assertEqual "$OLD_ALS" "$(alias)"

--- a/tests/sh/test_project_options.sh
+++ b/tests/sh/test_project_options.sh
@@ -11,8 +11,13 @@ OLD_PS1="${PS1:-}"
 
 assertEqual "$OLD_PATH" "$PATH" 
 assertEqual "$OLD_ALS" "$(alias)"
+
 # cut off the leading characters
-assertEqual "$(echo $PS1 | cut -c 9-)" "(my long project name 1337 !_\$#? 3)"
+if [[ -n "${BASH:-}" ]] ; then
+    assertEqual "$(echo $PS1 | cut -c 9-)" "(my long project name 1337 !_\$#? 3)"
+elif [[ -n "${ZSH_VERSION:-}" ]] ; then
+    assertEqual "$(echo $PS1 | cut -c 8-)" "(my long project name 1337 !_\$#? 3) "
+fi
 
 unsource
 

--- a/tests/sh/test_python_venv.sh
+++ b/tests/sh/test_python_venv.sh
@@ -7,7 +7,7 @@ OLD_PATH="$PATH"
 OLD_ALS=$(alias)
 OLD_PS1="${PS1:-}"
 
-. envr.ps1
+. ./envr.ps1
 
 # Python venv stuff is there
 assertEqual "$(pwd)/venv/bin:$OLD_PATH" "$PATH"

--- a/tests/sh/zsh.sh
+++ b/tests/sh/zsh.sh
@@ -2,7 +2,9 @@
 
 source tests/sh/helpers.sh
 
-echo -e "Running tests on zsh"
+_ZSH_VERSION=$(zsh --version)
+
+echo -e "Running tests on ${_ZSH_VERSION}"
 
 rm envr-local 2> /dev/null
 
@@ -14,19 +16,19 @@ runtest zsh project_options
 runtest zsh aliases
 runtest zsh path
 
-create a python venv
-python3 -m venv venv
-runtest zsh python_venv
-rm -Rf venv
+# create a python venv
+# python3 -m venv venv
+# runtest zsh python_venv
+# rm -Rf venv
 
 runtest zsh full
 
-rm envr-local
+rm envr-local 2> /dev/null
 
 if [[ $RES = 0 ]] ; then
-    echo -e "${GRN}GNU bash ${BASH_VERSION} passed!${RST} 🎉"    
+    echo -e "${GRN}${_ZSH_VERSION} passed!${RST} 🎉"    
 else 
-    echo -e "${RED}GNU bash ${BASH_VERSION} failed!${RST} 🤬"
+    echo -e "${RED}${_ZSH_VERSION} failed!${RST} 🤬"
 fi
 
 exit $RES


### PR DESCRIPTION
Add some limited support for zsh 5.8

Tested fixtures:
- empty
- envars
- project_options (though the prompt prefix is not working)
- path

TODO: aliases