### PR TITLE
fix: correct ANSI escapes for ZSH prompt

### DIFF
--- a/envr.ps1
+++ b/envr.ps1
@@ -1,4 +1,4 @@
-# envr v0.5.3
+# envr v0.5.4
 # https://www.github.com/JPHutchins/envr
 # https://www.crumpledpaper.tech
 
@@ -270,7 +270,7 @@ _envr_set_prompt_prefix () {
         if [[ -n "${BASH:-}" ]] ; then
             PS1="\[\033[0;36m\](${_PROMPT}) ${PS1:-}"
         elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-            PS1="\033[0;36m(${_PROMPT}) ${PS1:-}"
+            PS1="%F{36}(${_PROMPT})%F{reset} ${PS1:-}"
         fi
         
         export PS1

--- a/tests/sh/test_aliases.sh
+++ b/tests/sh/test_aliases.sh
@@ -30,7 +30,7 @@ assertEqual "$(args User args)" "User args"
 if [[ -n "${BASH:-}" ]] ; then
     assertEqual "$(echo $PS1 | cut -c 15-)" "(envr)"
 elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-    assertEqual "$(echo $PS1 | cut -c 8-)" "(envr) "
+    assertEqual "$(echo $PS1)" "%F{36}(envr)%F{reset} "
 fi
 
 # some error is getting caught by unsource but it's not apparent in

--- a/tests/sh/test_empty.sh
+++ b/tests/sh/test_empty.sh
@@ -18,7 +18,7 @@ assertEqual $(pwd) $(echo $ENVR_ROOT)
 if [[ -n "${BASH:-}" ]] ; then
     assertEqual "$(echo $PS1 | cut -c 15-)" "(envr)"
 elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-    assertEqual "$(echo $PS1 | cut -c 8-)" "(envr) "
+    assertEqual "$(echo $PS1)" "%F{36}(envr)%F{reset} "
 fi
 
 unsource

--- a/tests/sh/test_full.sh
+++ b/tests/sh/test_full.sh
@@ -32,7 +32,7 @@ assertNotEqual "$OLD_PS1" "${PS1:-}"
 if [[ -n "${BASH:-}" ]] ; then
     assertEqual "$(echo $PS1 | cut -c 15-)" "(poopsmith)"
 elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-    assertEqual "$(echo $PS1 | cut -c 8-)" "(poopsmith) "
+    assertEqual "$(echo $PS1)" "%F{36}(poopsmith)%F{reset} "
 fi
 
 # test aliases

--- a/tests/sh/test_multi.sh
+++ b/tests/sh/test_multi.sh
@@ -33,7 +33,7 @@ assertNotEqual "$OLD_PS1" "${PS1:-}"
 if [[ -n "${BASH:-}" ]] ; then
     assertEqual "$(echo $PS1 | cut -c 15-)" "(2a)"
 elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-    assertEqual "$(echo $PS1 | cut -c 8-)" "(2a) "
+    assertEqual "$(echo $PS1)" "%F{36}(2a)%F{reset} "
 fi
 
 # test aliases

--- a/tests/sh/test_project_options.sh
+++ b/tests/sh/test_project_options.sh
@@ -16,7 +16,7 @@ assertEqual "$OLD_ALS" "$(alias)"
 if [[ -n "${BASH:-}" ]] ; then
     assertEqual "$(echo $PS1 | cut -c 15-)" "(my long project name 1337 !_*#? 3)"
 elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-    assertEqual "$(echo $PS1 | cut -c 8-)" "(my long project name 1337 !_*#? 3) "
+    assertEqual "$(echo $PS1)" "%F{36}(my long project name 1337 !_*#? 3)%F{reset} "
 fi
 
 assertEqual "my long project name 1337 !_*#? 3" "$ENVR_PROJECT_NAME"

--- a/tests/sh/test_python_venv.sh
+++ b/tests/sh/test_python_venv.sh
@@ -19,7 +19,7 @@ assertEqual "$OLD_ALS" "$(alias)"
 if [[ -n "${BASH:-}" ]] ; then
     assertEqual "$(echo $PS1 | cut -c 15-)" "(envr)"
 elif [[ -n "${ZSH_VERSION:-}" ]] ; then
-    assertEqual "$(echo $PS1 | cut -c 8-)" "(envr) "
+    assertEqual "$(echo $PS1)" "%F{36}(envr)%F{reset} "
 fi
 
 unsource


### PR DESCRIPTION
fixes #18 